### PR TITLE
Track total RF/Mana consumption per boosted block

### DIFF
--- a/src/generated/resources/assets/blockbooster/lang/en_us.json
+++ b/src/generated/resources/assets/blockbooster/lang/en_us.json
@@ -9,6 +9,7 @@
   "gui.block_booster_t3": "Block Booster Tier 3",
   "gui.boost.slow_block": "§cSlow block - not boosting",
   "gui.boost.time": "§7Boost time: %s ms",
+  "gui.boost.total_consumed": "§eTotal consumed: %s %s",
   "gui.checkbox.boost": "Boost",
   "gui.creative": "Creative Player can see block ids",
   "gui.energy.info": "Energy: %s/%s FE",

--- a/src/main/java/igentuman/blockbooster/client/screen/BoosterManaScreen.java
+++ b/src/main/java/igentuman/blockbooster/client/screen/BoosterManaScreen.java
@@ -3,6 +3,7 @@ package igentuman.blockbooster.client.screen;
 import igentuman.blockbooster.BlockBooster;
 import igentuman.blockbooster.client.screen.element.CheckBox;
 import igentuman.blockbooster.container.BoosterManaContainer;
+import igentuman.blockbooster.util.BoosterUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractButton;
@@ -134,12 +135,16 @@ public class BoosterManaScreen extends AbstractContainerScreen<BoosterManaContai
             BlockEntity be = attachedBlocks.get(posKey);
             if(be != null && !be.isRemoved()) {
                 int blockY = startY + index * blockSpacing;
-                if(x >= blockIconX && x < blockIconX + blockIconSize && 
+                if(x >= blockIconX && x < blockIconX + blockIconSize &&
                    y >= blockY && y < blockY + blockIconSize) {
                     ItemStack blockStack = new ItemStack(be.getBlockState().getBlock().asItem());
                     List<Component> tooltip = new ArrayList<>();
                     tooltip.add(Component.translatable(blockStack.getDescriptionId()));
                     tooltip.add(Component.literal(be.getBlockPos().toShortString()));
+                    long total = menu.getTotalResourceConsumed(posKey);
+                    tooltip.add(Component.translatable("gui.boost.total_consumed",
+                            BoosterUtil.formatCompactAmount(total),
+                            menu.getResourceUnit()));
                     graphics.renderTooltip(Minecraft.getInstance().font, tooltip, Optional.empty(), x, y);
                     return;
                 }

--- a/src/main/java/igentuman/blockbooster/client/screen/BoosterT1Screen.java
+++ b/src/main/java/igentuman/blockbooster/client/screen/BoosterT1Screen.java
@@ -3,6 +3,7 @@ package igentuman.blockbooster.client.screen;
 import igentuman.blockbooster.BlockBooster;
 import igentuman.blockbooster.client.screen.element.CheckBox;
 import igentuman.blockbooster.container.BoosterT1Container;
+import igentuman.blockbooster.util.BoosterUtil;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
@@ -138,12 +139,16 @@ public class BoosterT1Screen extends AbstractContainerScreen<BoosterT1Container>
             BlockEntity be = attachedBlocks.get(posKey);
             if(be != null && !be.isRemoved()) {
                 int blockY = startY + index * blockSpacing;
-                if(x >= blockIconX && x < blockIconX + blockIconSize && 
+                if(x >= blockIconX && x < blockIconX + blockIconSize &&
                    y >= blockY && y < blockY + blockIconSize) {
                     ItemStack blockStack = new ItemStack(be.getBlockState().getBlock().asItem());
                     List<Component> tooltip = new ArrayList<>();
                     tooltip.add(Component.translatable(blockStack.getDescriptionId()));
                     tooltip.add(Component.literal(be.getBlockPos().toShortString()));
+                    long total = menu.getTotalResourceConsumed(posKey);
+                    tooltip.add(Component.translatable("gui.boost.total_consumed",
+                            BoosterUtil.formatCompactAmount(total),
+                            menu.getResourceUnit()));
                     graphics.renderTooltip(Minecraft.getInstance().font, tooltip, Optional.empty(), x, y);
                     return;
                 }

--- a/src/main/java/igentuman/blockbooster/client/screen/BoosterT2Screen.java
+++ b/src/main/java/igentuman/blockbooster/client/screen/BoosterT2Screen.java
@@ -3,6 +3,7 @@ package igentuman.blockbooster.client.screen;
 import igentuman.blockbooster.BlockBooster;
 import igentuman.blockbooster.client.screen.element.CheckBox;
 import igentuman.blockbooster.container.BoosterT2Container;
+import igentuman.blockbooster.util.BoosterUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractButton;
@@ -80,12 +81,16 @@ public class BoosterT2Screen extends AbstractContainerScreen<BoosterT2Container>
             BlockEntity be = attachedBlocks.get(posKey);
             if(be != null && !be.isRemoved()) {
                 int blockY = startY + index * blockSpacing;
-                if(x >= blockIconX && x < blockIconX + blockIconSize && 
+                if(x >= blockIconX && x < blockIconX + blockIconSize &&
                    y >= blockY && y < blockY + blockIconSize) {
                     ItemStack blockStack = new ItemStack(be.getBlockState().getBlock().asItem());
                     List<Component> tooltip = new ArrayList<>();
                     tooltip.add(Component.translatable(blockStack.getDescriptionId()));
                     tooltip.add(Component.literal(be.getBlockPos().toShortString()));
+                    long total = menu.getTotalResourceConsumed(posKey);
+                    tooltip.add(Component.translatable("gui.boost.total_consumed",
+                            BoosterUtil.formatCompactAmount(total),
+                            menu.getResourceUnit()));
                     graphics.renderTooltip(Minecraft.getInstance().font, tooltip, Optional.empty(), x, y);
                     return;
                 }

--- a/src/main/java/igentuman/blockbooster/client/screen/BoosterT3Screen.java
+++ b/src/main/java/igentuman/blockbooster/client/screen/BoosterT3Screen.java
@@ -3,6 +3,7 @@ package igentuman.blockbooster.client.screen;
 import igentuman.blockbooster.BlockBooster;
 import igentuman.blockbooster.client.screen.element.CheckBox;
 import igentuman.blockbooster.container.BoosterT3Container;
+import igentuman.blockbooster.util.BoosterUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractButton;
@@ -96,24 +97,29 @@ public class BoosterT3Screen extends AbstractContainerScreen<BoosterT3Container>
                 int blockX = startX + colIndex * columnSpacing;
                 int blockY = startY + rowIndex * blockSpacing;
                 
-                if(x >= blockX && x < blockX + blockIconSize && 
+                if(x >= blockX && x < blockX + blockIconSize &&
                    y >= blockY && y < blockY + blockIconSize) {
                     ItemStack blockStack = new ItemStack(be.getBlockState().getBlock().asItem());
                     List<Component> tooltip = new ArrayList<>();
                     tooltip.add(Component.translatable(blockStack.getDescriptionId()));
                     tooltip.add(Component.literal(be.getBlockPos().toShortString()));
-                    
+
                     // Add boost time information
                     Long boostTime = boostTimes.get(key);
                     if(boostTime != null && boostTime > 0) {
                         double timeMs = boostTime / 1_000_000.0;
                         tooltip.add(Component.translatable("gui.boost.time", String.format("%.3f", timeMs)));
-                        
+
                         if(menu.isSlowBlock(key)) {
                             tooltip.add(Component.translatable("gui.boost.slow_block"));
                         }
                     }
-                    
+
+                    long total = menu.getTotalResourceConsumed(key);
+                    tooltip.add(Component.translatable("gui.boost.total_consumed",
+                            BoosterUtil.formatCompactAmount(total),
+                            menu.getResourceUnit()));
+
                     graphics.renderTooltip(Minecraft.getInstance().font, tooltip, Optional.empty(), x, y);
                     return;
                 }

--- a/src/main/java/igentuman/blockbooster/container/BoosterManaContainer.java
+++ b/src/main/java/igentuman/blockbooster/container/BoosterManaContainer.java
@@ -81,4 +81,12 @@ public class BoosterManaContainer extends AbstractContainerMenu {
     public int getMaxMana() {
         return blockEntity.getMaxMana();
     }
+
+    public long getTotalResourceConsumed(long posKey) {
+        return blockEntity.getTotalResourceConsumed(posKey);
+    }
+
+    public String getResourceUnit() {
+        return blockEntity.getResourceUnit();
+    }
 }

--- a/src/main/java/igentuman/blockbooster/container/BoosterT1Container.java
+++ b/src/main/java/igentuman/blockbooster/container/BoosterT1Container.java
@@ -81,4 +81,12 @@ public class BoosterT1Container extends AbstractContainerMenu {
     public int getMaxEnergy() {
         return blockEntity.getMaxEnergy();
     }
+
+    public long getTotalResourceConsumed(long posKey) {
+        return blockEntity.getTotalResourceConsumed(posKey);
+    }
+
+    public String getResourceUnit() {
+        return blockEntity.getResourceUnit();
+    }
 }

--- a/src/main/java/igentuman/blockbooster/container/BoosterT2Container.java
+++ b/src/main/java/igentuman/blockbooster/container/BoosterT2Container.java
@@ -80,4 +80,12 @@ public class BoosterT2Container extends AbstractContainerMenu {
     public HashMap<Long, Boolean> getBoostFlags() {
         return blockEntity.getBoostFlags();
     }
+
+    public long getTotalResourceConsumed(long posKey) {
+        return blockEntity.getTotalResourceConsumed(posKey);
+    }
+
+    public String getResourceUnit() {
+        return blockEntity.getResourceUnit();
+    }
 }

--- a/src/main/java/igentuman/blockbooster/container/BoosterT3Container.java
+++ b/src/main/java/igentuman/blockbooster/container/BoosterT3Container.java
@@ -88,4 +88,12 @@ public class BoosterT3Container extends AbstractContainerMenu {
     public boolean isSlowBlock(long posKey) {
         return blockEntity.isSlowBlock(posKey);
     }
+
+    public long getTotalResourceConsumed(long posKey) {
+        return blockEntity.getTotalResourceConsumed(posKey);
+    }
+
+    public String getResourceUnit() {
+        return blockEntity.getResourceUnit();
+    }
 }

--- a/src/main/java/igentuman/blockbooster/datagen/BbLanguageProvider.java
+++ b/src/main/java/igentuman/blockbooster/datagen/BbLanguageProvider.java
@@ -28,6 +28,7 @@ public class BbLanguageProvider extends LanguageProvider {
         add("gui.tps.boosting_paused", "§7Boosting paused due to lag");
         add("gui.boost.time", "§7Boost time: %s ms");
         add("gui.boost.slow_block", "§cSlow block - not boosting");
+        add("gui.boost.total_consumed", "§eTotal consumed: %s %s");
         add("hint.booster_boost_rate", "Boost rate: x%s");
         add("hint.booster_fe_tick", "FE per boost: %s");
         add("hint.booster_mana_tick", "Mana per boost: %s");

--- a/src/main/java/igentuman/blockbooster/tile/AbstractBooster.java
+++ b/src/main/java/igentuman/blockbooster/tile/AbstractBooster.java
@@ -7,6 +7,8 @@ import igentuman.blockbooster.util.WorldUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.server.level.ServerLevel;
@@ -34,6 +36,7 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
     protected HashMap<Long, BlockEntity> attachedBlocks = new HashMap<>();
     protected HashMap<Long, Long> boostTimes = new HashMap<>();
     protected HashMap<Long, Boolean> boostFlags = new HashMap<>();
+    protected HashMap<Long, Long> totalResourceConsumed = new HashMap<>();
     public boolean isDisabled = false;
     public boolean isLagging = false;
     protected long tick = 0;
@@ -187,6 +190,7 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
             //clear out flags for removed blocks
             boostFlags.keySet().removeIf(key -> !attachedBlocks.containsKey(key));
             boostTimes.keySet().removeIf(key -> !attachedBlocks.containsKey(key));
+            totalResourceConsumed.keySet().removeIf(key -> !attachedBlocks.containsKey(key));
             setChanged();
             level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_ALL);
         }
@@ -274,7 +278,10 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
                 } else {
                     boostTimes.put(posKey, result.timeNanos);
                 }
-                consumeResource();
+                long consumed = consumeResource();
+                if (consumed > 0) {
+                    totalResourceConsumed.merge(posKey, consumed, Long::sum);
+                }
             }
         }
     }
@@ -290,8 +297,14 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
 
     /**
      * Consume the resource needed for boosting (energy, mana, etc.)
+     * @return the amount of resource consumed (used for per-block total tracking)
      */
-    protected abstract void consumeResource();
+    protected abstract long consumeResource();
+
+    /**
+     * Identifier of the resource unit displayed in the GUI (e.g. "FE", "Mana").
+     */
+    public abstract String getResourceUnit();
 
     /**
      * Save booster-specific data to NBT
@@ -323,6 +336,14 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
 
     public HashMap<Long, Boolean> getBoostFlags() {
         return boostFlags;
+    }
+
+    public HashMap<Long, Long> getTotalResourceConsumed() {
+        return totalResourceConsumed;
+    }
+
+    public long getTotalResourceConsumed(long posKey) {
+        return totalResourceConsumed.getOrDefault(posKey, 0L);
     }
 
     public boolean isIndexEnabled(long i) {
@@ -366,12 +387,14 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
     protected void saveClientData(CompoundTag tag) {
         tag.putBoolean("isDisabled", isDisabled);
         tag.putBoolean("isLagging", isLagging);
+        saveTotalResourceConsumed(tag);
         saveBoosterData(tag);
     }
 
     protected void loadClientData(CompoundTag tag) {
         isDisabled = tag.getBoolean("isDisabled");
         isLagging = tag.getBoolean("isLagging");
+        loadTotalResourceConsumed(tag);
         loadBoosterData(tag);
         if(attachedBlocks.size() != boostFlags.size()) {
             attachedBlocks.clear();
@@ -385,6 +408,7 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
     public void load(CompoundTag tag) {
         isDisabled = tag.getBoolean("isDisabled");
         isLagging = tag.getBoolean("isLagging");
+        loadTotalResourceConsumed(tag);
         loadBoosterData(tag);
         super.load(tag);
     }
@@ -393,7 +417,30 @@ public abstract class AbstractBooster extends BlockEntity implements BlockEntity
     public void saveAdditional(CompoundTag tag) {
         tag.putBoolean("isDisabled", isDisabled);
         tag.putBoolean("isLagging", isLagging);
+        saveTotalResourceConsumed(tag);
         saveBoosterData(tag);
+    }
+
+    protected void saveTotalResourceConsumed(CompoundTag tag) {
+        ListTag list = new ListTag();
+        for (Long key : totalResourceConsumed.keySet()) {
+            CompoundTag entry = new CompoundTag();
+            entry.putLong("posKey", key);
+            entry.putLong("total", totalResourceConsumed.get(key));
+            list.add(entry);
+        }
+        tag.put("totalResourceConsumed", list);
+    }
+
+    protected void loadTotalResourceConsumed(CompoundTag tag) {
+        if (tag.contains("totalResourceConsumed")) {
+            totalResourceConsumed.clear();
+            ListTag list = tag.getList("totalResourceConsumed", Tag.TAG_COMPOUND);
+            for (int i = 0; i < list.size(); i++) {
+                CompoundTag entry = list.getCompound(i);
+                totalResourceConsumed.put(entry.getLong("posKey"), entry.getLong("total"));
+            }
+        }
     }
 
     public boolean isLagging() {

--- a/src/main/java/igentuman/blockbooster/tile/TileBoosterMana.java
+++ b/src/main/java/igentuman/blockbooster/tile/TileBoosterMana.java
@@ -55,8 +55,14 @@ public class TileBoosterMana extends AbstractBooster implements ManaPool {
     }
 
     @Override
-    protected void consumeResource() {
+    protected long consumeResource() {
         consumeMana();
+        return manaPerTick;
+    }
+
+    @Override
+    public String getResourceUnit() {
+        return "Mana";
     }
 
     @Override

--- a/src/main/java/igentuman/blockbooster/tile/TileBoosterMechanical.java
+++ b/src/main/java/igentuman/blockbooster/tile/TileBoosterMechanical.java
@@ -49,8 +49,14 @@ public class TileBoosterMechanical extends AbstractBooster {
     }
 
     @Override
-    protected void consumeResource() {
+    protected long consumeResource() {
         consumeEnergy(fePerTick);
+        return fePerTick;
+    }
+
+    @Override
+    public String getResourceUnit() {
+        return "FE";
     }
 
     @Override

--- a/src/main/java/igentuman/blockbooster/tile/TileBoosterT1.java
+++ b/src/main/java/igentuman/blockbooster/tile/TileBoosterT1.java
@@ -42,8 +42,14 @@ public class TileBoosterT1 extends AbstractBooster {
     }
 
     @Override
-    protected void consumeResource() {
+    protected long consumeResource() {
         consumeEnergy(fePerTick);
+        return fePerTick;
+    }
+
+    @Override
+    public String getResourceUnit() {
+        return "FE";
     }
 
     @Override

--- a/src/main/java/igentuman/blockbooster/tile/TileBoosterT2.java
+++ b/src/main/java/igentuman/blockbooster/tile/TileBoosterT2.java
@@ -36,8 +36,14 @@ public class TileBoosterT2 extends AbstractBooster {
     }
 
     @Override
-    protected void consumeResource() {
+    protected long consumeResource() {
         consumeEnergy(fePerTick);
+        return fePerTick;
+    }
+
+    @Override
+    public String getResourceUnit() {
+        return "FE";
     }
 
     @Override

--- a/src/main/java/igentuman/blockbooster/tile/TileBoosterT3.java
+++ b/src/main/java/igentuman/blockbooster/tile/TileBoosterT3.java
@@ -96,6 +96,7 @@ public class TileBoosterT3 extends AbstractBooster {
             //clear out flags for removed blocks
             boostFlags.keySet().removeIf(key -> !attachedBlocks.containsKey(key));
             boostTimes.keySet().removeIf(key -> !attachedBlocks.containsKey(key));
+            totalResourceConsumed.keySet().removeIf(key -> !attachedBlocks.containsKey(key));
             setChanged();
             level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_ALL);
         }
@@ -112,8 +113,14 @@ public class TileBoosterT3 extends AbstractBooster {
     }
 
     @Override
-    protected void consumeResource() {
+    protected long consumeResource() {
         consumeEnergy(fePerTick);
+        return fePerTick;
+    }
+
+    @Override
+    public String getResourceUnit() {
+        return "FE";
     }
 
     @Override

--- a/src/main/java/igentuman/blockbooster/tile/TileBoosterTime.java
+++ b/src/main/java/igentuman/blockbooster/tile/TileBoosterTime.java
@@ -36,8 +36,14 @@ public class TileBoosterTime extends AbstractBooster {
     }
 
     @Override
-    protected void consumeResource() {
+    protected long consumeResource() {
         consumeEnergy(fePerTick);
+        return fePerTick;
+    }
+
+    @Override
+    public String getResourceUnit() {
+        return "FE";
     }
 
     @Override

--- a/src/main/java/igentuman/blockbooster/util/BoosterUtil.java
+++ b/src/main/java/igentuman/blockbooster/util/BoosterUtil.java
@@ -96,4 +96,28 @@ public class BoosterUtil {
             this.timeNanos = timeNanos;
         }
     }
+
+    /**
+     * Formats a resource amount into a compact human-readable string with SI suffix.
+     * Examples: 999 -> "999", 1500 -> "1.5K", 12_500_000 -> "12.5M", 3_400_000_000 -> "3.4G".
+     */
+    public static String formatCompactAmount(long amount) {
+        if (amount < 1000L) {
+            return Long.toString(amount);
+        }
+        String[] suffixes = {"K", "M", "G", "T", "P", "E"};
+        double value = amount;
+        int suffixIndex = -1;
+        while (value >= 1000.0 && suffixIndex < suffixes.length - 1) {
+            value /= 1000.0;
+            suffixIndex++;
+        }
+        if (value >= 100.0) {
+            return String.format("%.0f%s", value, suffixes[suffixIndex]);
+        }
+        if (value >= 10.0) {
+            return String.format("%.1f%s", value, suffixes[suffixIndex]);
+        }
+        return String.format("%.2f%s", value, suffixes[suffixIndex]);
+    }
 }

--- a/src/main/resources/assets/blockbooster/lang/ru_ru.json
+++ b/src/main/resources/assets/blockbooster/lang/ru_ru.json
@@ -15,5 +15,6 @@
   "gui.tps.current": "Текущий TPS: %s",
   "gui.tps.boosting_paused": "§7Ускорение приостановлено из-за лагов",
   "gui.boost.time": "§7Время ускорения: %s мс",
-  "gui.boost.slow_block": "§cМедленный блок - не бустится"
+  "gui.boost.slow_block": "§cМедленный блок - не бустится",
+  "gui.boost.total_consumed": "§eВсего потрачено: %s %s"
 }


### PR DESCRIPTION
## Summary

Each booster now records the cumulative resource (FE or Mana) it has spent on every individual attached block. Hovering over a block icon in the booster GUI surfaces the running total alongside the existing position and boost-time information.

## Changes

- **`AbstractBooster`**: new `HashMap<Long, Long> totalResourceConsumed` keyed by `posKey`, populated in `processBoostingLogic` after each successful boost. Stale entries are dropped together with `boostTimes` when a block leaves the scan.
- **API**: `consumeResource()` now returns the amount consumed (`long`) so the abstract base can aggregate without per-tier duplication. New `getResourceUnit()` lets each tier declare its unit (`"FE"` or `"Mana"`).
- **Persistence**: totals are saved in NBT (`saveAdditional`/`load`) and synced to the client via `saveClientData`/`loadClientData`, so the GUI reflects up-to-date values without extra packets.
- **All tiers updated**: `TileBoosterT1`, `T2`, `T3`, `Mana`, `Mechanical`, `Time`.
- **GUI**: tooltips on attached block icons in the T1/T2/T3/Mana screens now show `Total consumed: <amount> <unit>`. Amounts are rendered with a compact K/M/G/T formatter (`BoosterUtil.formatCompactAmount`).
- **i18n**: added `gui.boost.total_consumed` to `en_us.json`, `ru_ru.json`, and the `BbLanguageProvider`.